### PR TITLE
bugfix, CausalConv1d, CausalConv2d

### DIFF
--- a/src/models/encoders/e_branchformer.py
+++ b/src/models/encoders/e_branchformer.py
@@ -153,18 +153,19 @@ class ConvolutionalSpatialGatingUnit(torch.nn.Module):
             CausalConv1d(
                 n_channels,
                 n_channels,
-                config.csgu_kernel_size,
-                1,
-                (config.csgu_kernel_size - 1) // 2,
+                kernel_size=config.csgu_kernel_size,
+                stride=1,
+                dilation=1,
                 groups=n_channels,
             )
             if config.is_causal
             else torch.nn.Conv1d(
                 n_channels,
                 n_channels,
-                config.csgu_kernel_size,
-                1,
-                (config.csgu_kernel_size - 1) // 2,
+                kernel_size=config.csgu_kernel_size,
+                stride=1,
+                padding=(config.csgu_kernel_size - 1) // 2,
+                dilation=1,
                 groups=n_channels,
             )
         )

--- a/src/models/encoders/e_branchformer.py
+++ b/src/models/encoders/e_branchformer.py
@@ -246,14 +246,27 @@ class Wav2Vec2EBranchformerEncoderLayer(nn.Module):
         # Merge
         self.final_dropout = torch.nn.Dropout(dropout)
         self.merge_proj = torch.nn.Linear(embed_dim + embed_dim, embed_dim)
-        self.depthwise_conv_fusion = torch.nn.Conv1d(
-            embed_dim + embed_dim,
-            embed_dim + embed_dim,
-            kernel_size=config.merge_conv_kernel,
-            stride=1,
-            padding=(config.merge_conv_kernel - 1) // 2,
-            groups=embed_dim + embed_dim,
-            bias=True,
+        self.depthwise_conv_fusion = (
+            CausalConv1d(
+                embed_dim + embed_dim,
+                embed_dim + embed_dim,
+                kernel_size=config.merge_conv_kernel,
+                stride=1,
+                dilation=1,
+                groups=embed_dim + embed_dim,
+                bias=True,
+            )
+            if config.is_causal
+            else torch.nn.Conv1d(
+                embed_dim + embed_dim,
+                embed_dim + embed_dim,
+                kernel_size=config.merge_conv_kernel,
+                stride=1,
+                padding=(config.merge_conv_kernel - 1) // 2,
+                dilation=1,
+                groups=embed_dim + embed_dim,
+                bias=True,
+            )
         )
         self.final_layer_norm = nn.LayerNorm(embed_dim)
 

--- a/src/models/extractors.py
+++ b/src/models/extractors.py
@@ -1,4 +1,5 @@
 """This module contains the feature extractors for the ASR model."""
+
 from typing import Optional, Union
 
 import torch
@@ -11,8 +12,8 @@ from transformers.utils import logging
 from models.streaming_modules import CausalConv2d
 from models.utils import calculate_output_size_multilayer
 
-
 logger = logging.get_logger(__name__)
+
 
 class CustomFEConfig(PretrainedConfig):
     """This class contains the configuration for the feature extractor."""
@@ -85,27 +86,30 @@ class Conv2dFeatureExtractor(nn.Module):
         same amount of padding from all 4 sides (top, down, left, right).
         `pad1` for 1st module, `pad2` for 2nd module.
     """
+
     def __init__(self, config):
         super().__init__()
 
         self.conv = torch.nn.Sequential(
             *[
                 nn.Sequential(
-                    CausalConv2d(
-                        conv_in,
-                        out_channels=conv_out,
-                        kernel_size=(conv_kernel, conv_kernel),
-                        stride=(conv_stride, conv_stride),
-                        padding=_pair(conv_padding),
-                    )
-                    if hasattr(config, "is_causal") and config.is_causal
-                    else ContextAwareConv2d(
-                        conv_in,
-                        out_channels=conv_out,
-                        kernel_size=(conv_kernel, conv_kernel),
-                        stride=(conv_stride, conv_stride),
-                        padding=_pair(conv_padding),
-                        context_awareness_type=config.context_awareness_type,
+                    (
+                        CausalConv2d(
+                            conv_in,
+                            out_channels=conv_out,
+                            kernel_size=(conv_kernel, conv_kernel),
+                            stride=(conv_stride, conv_stride),
+                            padding=_pair(conv_padding),
+                        )
+                        if hasattr(config, "is_causal") and config.is_causal
+                        else ContextAwareConv2d(
+                            conv_in,
+                            out_channels=conv_out,
+                            kernel_size=(conv_kernel, conv_kernel),
+                            stride=(conv_stride, conv_stride),
+                            padding=_pair(conv_padding),
+                            context_awareness_type=config.context_awareness_type,
+                        )
                     ),
                     ACT2FN[config.feat_extract_activation],
                 )
@@ -126,7 +130,9 @@ class Conv2dFeatureExtractor(nn.Module):
                         _pair(conv_padding)[1],  # right_padding (not on time axis)
                     )
                     for conv_kernel, conv_stride, conv_padding in zip(
-                        config.conv_kernel, config.conv_stride, config.conv_padding,
+                        config.conv_kernel,
+                        config.conv_stride,
+                        config.conv_padding,
                     )
                 ],
             )

--- a/src/models/extractors.py
+++ b/src/models/extractors.py
@@ -3,12 +3,16 @@ from typing import Optional, Union
 
 import torch
 from torch import nn
+from torch.nn.modules.utils import _pair
 from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import logging
 
 from models.streaming_modules import CausalConv2d
 from models.utils import calculate_output_size_multilayer
 
+
+logger = logging.get_logger(__name__)
 
 class CustomFEConfig(PretrainedConfig):
     """This class contains the configuration for the feature extractor."""
@@ -66,8 +70,24 @@ class ContextAwareConv2d(nn.Module):
 
 
 class Conv2dFeatureExtractor(nn.Module):
+    """
+    config.conv_padding:
+        padding for Conv2d, pads the input on all 4 sides.
+
+        option1:
+        `[[ time_pad1, dim_pad1], [ time_pad2, dim_pad2 ]]`
+        pads separately rows and columns in the 2 Conv2d modules.
+        `time_pad1` adds frames both to the beginning and the
+        end of the sequence.
+
+        option2:
+        `[ pad1, pad2 ]`
+        same amount of padding from all 4 sides (top, down, left, right).
+        `pad1` for 1st module, `pad2` for 2nd module.
+    """
     def __init__(self, config):
         super().__init__()
+
         self.conv = torch.nn.Sequential(
             *[
                 nn.Sequential(
@@ -76,7 +96,7 @@ class Conv2dFeatureExtractor(nn.Module):
                         out_channels=conv_out,
                         kernel_size=(conv_kernel, conv_kernel),
                         stride=(conv_stride, conv_stride),
-                        padding=conv_padding,
+                        padding=_pair(conv_padding),
                     )
                     if hasattr(config, "is_causal") and config.is_causal
                     else ContextAwareConv2d(
@@ -84,7 +104,7 @@ class Conv2dFeatureExtractor(nn.Module):
                         out_channels=conv_out,
                         kernel_size=(conv_kernel, conv_kernel),
                         stride=(conv_stride, conv_stride),
-                        padding=conv_padding,
+                        padding=_pair(conv_padding),
                         context_awareness_type=config.context_awareness_type,
                     ),
                     ACT2FN[config.feat_extract_activation],
@@ -94,13 +114,19 @@ class Conv2dFeatureExtractor(nn.Module):
                 )
             ],
         )
+
         linear_in_dim = config.conv_dim[-1] * int(
             calculate_output_size_multilayer(
                 config.num_fbanks,
                 [
-                    (conv_kernel, conv_stride, conv_padding, conv_padding)
+                    (
+                        conv_kernel,
+                        conv_stride,
+                        _pair(conv_padding)[1],  # left_padding (not on time axis)
+                        _pair(conv_padding)[1],  # right_padding (not on time axis)
+                    )
                     for conv_kernel, conv_stride, conv_padding in zip(
-                        config.conv_kernel, config.conv_stride, config.conv_padding
+                        config.conv_kernel, config.conv_stride, config.conv_padding,
                     )
                 ],
             )
@@ -139,21 +165,23 @@ class CustomFE:
         # pylint: disable=no-member
         add_adapter = self.config.add_adapter if add_adapter is None else add_adapter
 
-        def _conv_out_length(input_length, kernel_size, stride):
+        def _conv_out_length(input_length, kernel_size, stride, time_padding):
             # 1D convolutional layer output length formula taken
             # from https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html
-
-            return torch.div(input_length - kernel_size, stride, rounding_mode="floor") + 1
+            #
+            # assumed: dilation=1
+            return torch.div(input_length + time_padding - kernel_size, stride, rounding_mode="floor") + 1
 
         # pylint: disable=no-member
-        for kernel_size, stride, conv_padding in zip(
+        for kernel_size, stride, padding in zip(
             self.config.conv_kernel, self.config.conv_stride, self.config.conv_padding
         ):
             input_lengths = _conv_out_length(
                 # pylint: disable=no-member
-                input_lengths + (kernel_size - 1 if self.config.is_causal else 2 * conv_padding),
+                input_lengths,
                 kernel_size,
                 stride,
+                2 * _pair(padding)[0],  # top_padding + bottom_padding (on time axis)
             )
 
         if add_adapter:

--- a/src/models/streaming_modules.py
+++ b/src/models/streaming_modules.py
@@ -5,9 +5,12 @@ import torch.nn.functional as F
 from torch import nn
 from torch.nn.modules.utils import _pair
 from transformers import PreTrainedModel
+from transformers.utils import logging
 
 from models.utils import calculate_output_size
 
+
+logger = logging.get_logger(__name__)
 
 class CausalConv1d(torch.nn.Conv1d):
     def __init__(self, in_channels, out_channels, kernel_size, stride=1, dilation=1, groups=1, bias=True):
@@ -29,30 +32,28 @@ class CausalConv1d(torch.nn.Conv1d):
 
 
 class CausalConv2d(nn.Conv2d):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=None, dilation=1, groups=1, bias=True):
+    """
+    Vanilla Conv2d, subclassed so the name `CausalConv2d` appears in the model.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)
         dilation = _pair(dilation)
-        if padding is None:
-            padding = (int((kernel_size[0] - 1) * dilation[0]), padding)
-        else:
-            padding = padding * 2
-        self.left_padding = _pair(padding)
+        assert len(padding) == 2  # already is _pair()
+
         super().__init__(
             in_channels,
             out_channels,
             kernel_size,
             stride=stride,
-            padding=0,
+            padding=padding,
             dilation=dilation,
             groups=groups,
             bias=bias,
         )
 
     def forward(self, inputs):
-        inputs = F.pad(inputs, (self.left_padding[1], 0, self.left_padding[0], 0))
-        output = super().forward(inputs)
-        return output
+        return super().forward(inputs)
 
 
 class FeatureExtractorForStreaming(PreTrainedModel):

--- a/src/models/streaming_modules.py
+++ b/src/models/streaming_modules.py
@@ -9,8 +9,8 @@ from transformers.utils import logging
 
 from models.utils import calculate_output_size
 
-
 logger = logging.get_logger(__name__)
+
 
 class CausalConv1d(torch.nn.Conv1d):
     def __init__(self, in_channels, out_channels, kernel_size, stride=1, dilation=1, groups=1, bias=True):
@@ -35,6 +35,7 @@ class CausalConv2d(nn.Conv2d):
     """
     Vanilla Conv2d, subclassed so the name `CausalConv2d` appears in the model.
     """
+
     def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=True):
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)

--- a/src/models/utils.py
+++ b/src/models/utils.py
@@ -1,5 +1,10 @@
-import torch
+from typing import Union
 
+import torch
+from transformers.utils import logging
+
+
+logger = logging.get_logger(__name__)
 
 def calculate_output_size(input_size, kernel_size, stride, left_padding=0, right_padding=0, dilation=1):
     """
@@ -9,8 +14,10 @@ def calculate_output_size(input_size, kernel_size, stride, left_padding=0, right
     - input_size: Input size (width or height)
     - kernel_size: Kernel size
     - stride: Stride
-    - left_padding: Left padding
-    - right_padding: Right padding
+   - left_padding: Left padding, not over time axis, zeros are prepended to each line of the feature matrix.
+                      [[ 0.0, 0.0, x1, x2, ..., xk ], ... ]
+    - right_padding: Right padding, not over time axis, zeros are appended to each line of the feature matrix.
+                      [[ x1, x2, ..., xk, 0.0, 0.0 ], ... ]
 
     Returns:
     - Output size

--- a/src/models/utils.py
+++ b/src/models/utils.py
@@ -3,24 +3,24 @@ from typing import Union
 import torch
 from transformers.utils import logging
 
-
 logger = logging.get_logger(__name__)
+
 
 def calculate_output_size(input_size, kernel_size, stride, left_padding=0, right_padding=0, dilation=1):
     """
-    Calculate the output size after a convolution operation with separate left and right padding.
+     Calculate the output size after a convolution operation with separate left and right padding.
 
-    Parameters:
-    - input_size: Input size (width or height)
-    - kernel_size: Kernel size
-    - stride: Stride
-   - left_padding: Left padding, not over time axis, zeros are prepended to each line of the feature matrix.
-                      [[ 0.0, 0.0, x1, x2, ..., xk ], ... ]
-    - right_padding: Right padding, not over time axis, zeros are appended to each line of the feature matrix.
-                      [[ x1, x2, ..., xk, 0.0, 0.0 ], ... ]
+     Parameters:
+     - input_size: Input size (width or height)
+     - kernel_size: Kernel size
+     - stride: Stride
+    - left_padding: Left padding, not over time axis, zeros are prepended to each line of the feature matrix.
+                       [[ 0.0, 0.0, x1, x2, ..., xk ], ... ]
+     - right_padding: Right padding, not over time axis, zeros are appended to each line of the feature matrix.
+                       [[ x1, x2, ..., xk, 0.0, 0.0 ], ... ]
 
-    Returns:
-    - Output size
+     Returns:
+     - Output size
     """
     if not isinstance(input_size, torch.Tensor):
         input_size = torch.tensor(input_size)


### PR DESCRIPTION
- CausalConv1d : dilation=15 -> dilation=1 in forward()
- CausalConv2d :
   - the conv_padding can be applied separately to time axis and dim axis
   - in previous code, the output dim depends on `config.conv_padding`
   - in past we added 2 zero rows and 2 zero cols at the top-left corner -> now we add rows/cols from both sides (to have smaller artifacts)
   - the code should be compatible with older models (small shift of input of `CausalConv2d` should not be important)